### PR TITLE
Upgrade the typescript generation plugin.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,6 +94,5 @@ lazy val typescriptClasses = (project in file("ts"))
 
     Compile / scroogeLanguages := Seq("typescript"),
     scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
-    scroogeTypescriptPackageLicense := "Apache-2.0",
-    scroogeTypescriptDryRun := true
+    scroogeTypescriptPackageLicense := "Apache-2.0"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -94,5 +94,6 @@ lazy val typescriptClasses = (project in file("ts"))
 
     Compile / scroogeLanguages := Seq("typescript"),
     scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
-    scroogeTypescriptPackageLicense := "Apache-2.0"
+    scroogeTypescriptPackageLicense := "Apache-2.0",
+    scroogeTypescriptDryRun := true
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
 
 resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.3")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 


### PR DESCRIPTION
It now publishes `.d.ts` files alongside the compiled `.js` files, rather than `.ts` and `.js` as it was initially set up.

This ensures the client project that consumes the NPM package doesn't get any compilation error coming from the generated library.