### PR TITLE
removing references to bintray repos as bintray is end of life

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,4 @@
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
-
-resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.3")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.7-RC1")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.7-RC1")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.3.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 


### PR DESCRIPTION
This PR removes a bintray resolver as bintray is being retired.

Resolver details:

- guardian - This was used for the sbt-scrooge-typescript which has been updated to a version that is available from maven central. (Wait for a full release)