### PR TITLE
Bump sbt to 1.5.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,14 +57,16 @@ lazy val scalaClasses = (project in file("scala"))
     name := "content-entity-model",
     description := "Scala library built from Content-entity thrift definition",
 
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
-    scroogeThriftOutputFolder in Compile := sourceManaged.value,
-    scroogePublishThrift in Compile := true,
-    managedSourceDirectories in Compile += (scroogeThriftOutputFolder in Compile).value,
+    Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
+    Compile / scroogeThriftOutputFolder := sourceManaged.value,
+    Compile / scroogePublishThrift := true,
+    Compile / scroogeThriftIncludeRoot := false,
+    Global / excludeLintKeys += scroogeThriftIncludeRoot,
+    Compile / managedSourceDirectories += (Compile / scroogeThriftOutputFolder).value,
 
     libraryDependencies ++= Seq(
       "org.apache.thrift" % "libthrift" % "0.13.0",
-      "com.twitter" %% "scrooge-core" % "20.4.1",
+      "com.twitter" %% "scrooge-core" % "21.3.0",
       "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
     )
   )
@@ -76,9 +78,9 @@ lazy val thrift = (project in file("thrift"))
     name := "content-entity-thrift",
     description := "Content entity model Thrift files",
     crossPaths := false,
-    publishArtifact in packageDoc := false,
-    publishArtifact in packageSrc := false,
-    unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" }
+    packageDoc / publishArtifact:= false,
+    packageSrc / publishArtifact := false,
+    Compile / unmanagedResourceDirectories += { baseDirectory.value / "src/main/thrift" }
   )
 
 lazy val typescriptClasses = (project in file("ts"))
@@ -93,6 +95,6 @@ lazy val typescriptClasses = (project in file("ts"))
     description := "Typescript library built from Content-entity thrift definition",
 
     Compile / scroogeLanguages := Seq("typescript"),
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
+    Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
     scroogeTypescriptPackageLicense := "Apache-2.0"
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "20.4.1")
 
 resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.2.3")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.3.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.3.0")
+

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.7-SNAPSHOT"
+ThisBuild / version := "2.0.7-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

Bumps sbt to 1.5.7 to address log4j vulnerability concerns.

In addition, this PR resolves warnings around multi-thrift compilation (cf. https://github.com/guardian/ophan/pull/3973).

## How to test

sbt compiles successfully. 