### PR TITLE
Updating sbt, dependencies, plugins etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 generated
 target/
 .idea/
+.bsp/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This will release 2 artifacts to Maven Central:
 * `content-entity-model_2.13-$version.jar` contains the Thrift files and Scrooge-generated Scala 2.13 classes
 * `content-entity-model-thrift-$version.jar` contains only the Thrift files
 
-The package is cross-built against Scala 2.13, 2.12 and 2.11
+The package is cross-built against Scala 2.13 and 2.12. Support for Scala 2.11 ended with Scrooge 21.3.0.
+
 You will need a PGP key and Sonatype credentials.  
 
 This will also release the js/typescript package on NPM.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Ensure you have the following installed on your machine:
  
 Ensure you have an NPM account, part of the [@guardian](https://www.npmjs.com/org/guardian) org with a [configured token](https://docs.npmjs.com/creating-and-viewing-authentication-tokens)
 
+### New!
+Beta releases from a WIP branch can be deployed to Maven & npm. To do this, start sbt with
+`sbt -DRELEASE_TYPE=beta`
+When you follow the remaining instructions, you'll see a couple of new prompts and version number formats. We leave it
+up to the developer to keep track of the versions you've released this way, but you should always update the next 
+version to reflect the beta status of the code (i.e. don't just let it revert to -SNAPSHOT which it will want to do by 
+default). This is particularly important for npmRelease which you have to manually supply with a version number. Just
+use the same version identifier as you released to Maven.
+
+If you don't wish to make a beta release, just start sbt as normal (without the -DRELEASE_TYPE parameter) and continue
+with the steps that follow.
+
 ```sbtshell
 release // will release the scala / thrift projects
 project typescriptClasses

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val mavenSettings = Seq(
       </developers>
     ),
   licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-  publishTo := sonatypePublishTo.value,
+  publishTo := sonatypePublishToBundle.value,
   publishConfiguration := publishConfiguration.value.withOverwrite(true)
 )
 
@@ -70,8 +70,8 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
     tagRelease,
     publishArtifacts,
     setNextVersion,
-    releaseStepCommand("publishSigned"),  // consider releaseStepCommandAndRemaining +publishSigned?
-    releaseStepCommand("sonatypeRelease"),
+    releaseStepCommandAndRemaining("+publishSigned"),
+    releaseStepCommand("sonatypeBundleRelease"),
     commitNextVersion
   )
 
@@ -89,8 +89,8 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
   */
   val candidateSteps: Seq[ReleaseStep] = Seq(
     setReleaseVersion,
-    releaseStepCommand("publishSigned"),  // consider releaseStepCommandAndRemaining +publishSigned?
-    releaseStepCommand("sonatypeRelease"),
+    releaseStepCommandAndRemaining("+publishSigned"),
+    releaseStepCommand("sonatypeBundleRelease"),
     setNextVersion
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,15 @@
 import sbtrelease._
 import ReleaseStateTransformations._
 
+val scroogeVersion = "21.12.0"
+val thriftVersion = "0.15.0"
+
 val commonSettings = Seq(
   organization := "com.gu",
   scalaVersion := "2.13.2",
-  crossScalaVersions := Seq("2.11.12", "2.12.11", "2.13.2"),
+  // scrooge 21.3.0: Builds are now only supported for Scala 2.12+
+  // https://twitter.github.io/scrooge/changelog.html#id11
+  crossScalaVersions := Seq("2.12.11", scalaVersion.value),
   releaseCrossBuild := true,
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/content-entity"),
                           "scm:git:git@github.com:guardian/content-entity.git")),
@@ -21,6 +26,11 @@ val commonSettings = Seq(
       <id>tomrf1</id>
       <name>Tom Forbes</name>
       <url>https://github.com/tomrf1</url>
+    </developer>
+    <developer>
+      <id>justinpinner</id>
+      <name>Justin Pinner</name>
+      <url>https://github.com/justinpinner</url>
     </developer>
   </developers>
   ),
@@ -57,14 +67,14 @@ lazy val scalaClasses = (project in file("scala"))
     name := "content-entity-model",
     description := "Scala library built from Content-entity thrift definition",
 
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
-    scroogeThriftOutputFolder in Compile := sourceManaged.value,
-    scroogePublishThrift in Compile := true,
-    managedSourceDirectories in Compile += (scroogeThriftOutputFolder in Compile).value,
+    Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
+    Compile / scroogeThriftOutputFolder := sourceManaged.value,
+    Compile / scroogePublishThrift := true,
+    Compile / managedSourceDirectories += (Compile / scroogeThriftOutputFolder).value,
 
     libraryDependencies ++= Seq(
-      "org.apache.thrift" % "libthrift" % "0.13.0",
-      "com.twitter" %% "scrooge-core" % "20.4.1",
+      "org.apache.thrift" % "libthrift" % thriftVersion,
+      "com.twitter" %% "scrooge-core" % scroogeVersion,
       "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
     )
   )
@@ -76,9 +86,9 @@ lazy val thrift = (project in file("thrift"))
     name := "content-entity-thrift",
     description := "Content entity model Thrift files",
     crossPaths := false,
-    publishArtifact in packageDoc := false,
-    publishArtifact in packageSrc := false,
-    unmanagedResourceDirectories in Compile += { baseDirectory.value / "src/main/thrift" }
+    packageDoc / publishArtifact := false,
+    packageSrc / publishArtifact := false,
+    Compile / unmanagedResourceDirectories += { baseDirectory.value / "src/main/thrift" }
   )
 
 lazy val typescriptClasses = (project in file("ts"))
@@ -93,6 +103,6 @@ lazy val typescriptClasses = (project in file("ts"))
     description := "Typescript library built from Content-entity thrift definition",
 
     Compile / scroogeLanguages := Seq("typescript"),
-    scroogeThriftSourceFolder in Compile := baseDirectory.value / "../thrift/src/main/thrift",
+    Compile / scroogeThriftSourceFolder := baseDirectory.value / "../thrift/src/main/thrift",
     scroogeTypescriptPackageLicense := "Apache-2.0"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,103 @@ import ReleaseStateTransformations._
 
 val scroogeVersion = "21.12.0"
 val thriftVersion = "0.15.0"
+val candidateReleaseType = "candidate"
+val candidateReleaseSuffix = "-RC1"
+
+lazy val versionSettingsMaybe = {
+  sys.props.get("RELEASE_TYPE").map {
+    case v if v == candidateReleaseType => candidateReleaseSuffix
+  }.map { suffix =>
+    releaseVersion := {
+      ver => Version(ver).map(_.withoutQualifier.string).map(_.concat(suffix)).getOrElse(versionFormatError(ver))
+    }
+  }.toSeq
+}
+
+lazy val mavenSettings = Seq(
+  pomExtra := (
+    <url>https://github.com/guardian/content-entity</url>
+      <developers>
+        <developer>
+          <id>LATaylor-guardian</id>
+          <name>Luke Taylor</name>
+          <url>https://github.com/LATaylor-guardian</url>
+        </developer>
+        <developer>
+          <id>tomrf1</id>
+          <name>Tom Forbes</name>
+          <url>https://github.com/tomrf1</url>
+        </developer>
+        <developer>
+          <id>justinpinner</id>
+          <name>Justin Pinner</name>
+          <url>https://github.com/justinpinner</url>
+        </developer>
+      </developers>
+    ),
+  licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
+  publishTo := sonatypePublishTo.value,
+  publishConfiguration := publishConfiguration.value.withOverwrite(true)
+)
+
+lazy val checkReleaseType: ReleaseStep = ReleaseStep({ st: State =>
+  val releaseType = sys.props.get("RELEASE_TYPE").map {
+    case v if v == candidateReleaseType => candidateReleaseType.toUpperCase
+  }.getOrElse("PRODUCTION")
+
+  SimpleReader.readLine(s"This will be a $releaseType release. Continue? [y/N]: ") match {
+    case Some(v) if Seq("Y", "YES").contains(v.toUpperCase) => // we don't care about the value - it's a flow control mechanism
+    case _ => sys.error(s"Release aborted by user!")
+  }
+  // we haven't changed state, just pass it on if we haven't thrown an error from above
+  st
+})
+
+lazy val releaseProcessSteps: Seq[ReleaseStep] = {
+  val commonSteps = Seq(
+    checkReleaseType,
+    checkSnapshotDependencies,
+    inquireVersions,
+    runClean,
+    runTest
+  )
+
+  val prodSteps: Seq[ReleaseStep] = Seq(
+    setReleaseVersion,
+    commitReleaseVersion,
+    tagRelease,
+    publishArtifacts,
+    setNextVersion,
+    releaseStepCommand("publishSigned"),  // consider releaseStepCommandAndRemaining +publishSigned?
+    releaseStepCommand("sonatypeRelease"),
+    commitNextVersion
+  )
+
+  /*
+  Release Candidate assemblies can be published to Sonatype and Maven.
+
+  To make this work, start SBT with the candidate RELEASE_TYPE variable set;
+    sbt -DRELEASE_TYPE=candidate
+
+  This gets around the "problem" of sbt-sonatype assuming that a -SNAPSHOT build should not be delivered to Maven.
+
+  In this mode, the version number will be presented as e.g. 1.2.3-RC1, but the git tagging and version-updating
+  steps are not triggered, so it's up to the developer to keep track of what was released and manipulate subsequent
+  release and next versions appropriately.
+  */
+  val candidateSteps: Seq[ReleaseStep] = Seq(
+    setReleaseVersion,
+    releaseStepCommand("publishSigned"),  // consider releaseStepCommandAndRemaining +publishSigned?
+    releaseStepCommand("sonatypeRelease"),
+    setNextVersion
+  )
+
+  commonSteps ++ (sys.props.get("RELEASE_TYPE") match {
+    case Some(v) if v == candidateReleaseType => candidateSteps // this enables a release candidate build to sonatype and Maven
+    case None => prodSteps  // our normal deploy route
+  })
+
+}
 
 val commonSettings = Seq(
   organization := "com.gu",
@@ -13,52 +110,15 @@ val commonSettings = Seq(
   releaseCrossBuild := true,
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/content-entity"),
                           "scm:git:git@github.com:guardian/content-entity.git")),
-
-  pomExtra := (
-  <url>https://github.com/guardian/content-entity</url>
-  <developers>
-    <developer>
-      <id>LATaylor-guardian</id>
-      <name>Luke Taylor</name>
-      <url>https://github.com/LATaylor-guardian</url>
-    </developer>
-    <developer>
-      <id>tomrf1</id>
-      <name>Tom Forbes</name>
-      <url>https://github.com/tomrf1</url>
-    </developer>
-    <developer>
-      <id>justinpinner</id>
-      <name>Justin Pinner</name>
-      <url>https://github.com/justinpinner</url>
-    </developer>
-  </developers>
-  ),
-  licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-  publishTo := sonatypePublishTo.value,
-  publishConfiguration := publishConfiguration.value.withOverwrite(true),
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    inquireVersions,
-    runClean,
-    runTest,
-    setReleaseVersion,
-    commitReleaseVersion,
-    tagRelease,
-    publishArtifacts,
-    setNextVersion,
-    commitNextVersion,
-    releaseStepCommand("sonatypeRelease"),
-    pushChanges
-  )
-)
+  releasePublishArtifactsAction := PgpKeys.publishSigned.value
+) ++ mavenSettings ++ versionSettingsMaybe
 
 lazy val root = (project in file("."))
-  .aggregate(thrift, scalaClasses)
   .settings(commonSettings)
+  .aggregate(thrift, scalaClasses)
   .settings(
-    publishArtifact := false
+    publishArtifact := false,
+    releaseProcess := releaseProcessSteps
   )
 
 lazy val scalaClasses = (project in file("scala"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.4")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.5")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.5")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.6")
 
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.5.0-RC1")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.4")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.3.0")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.5.0-RC1")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.0-SNAPSHOT"
+ThisBuild / version := "2.1.0-RC2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.2.0-beta.4"
+ThisBuild / version := "2.2.0-beta.5"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.2.0-beta.3"
+ThisBuild / version := "2.2.0-beta.4"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.7-SNAPSHOT"
+ThisBuild / version := "2.1.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.0-RC3"
+version in ThisBuild := "2.2.0-beta.3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.1.0-RC2"
+ThisBuild / version := "2.1.0-RC3"


### PR DESCRIPTION
## What does this change?
Updates our version of sbt, scrooge and thrift and is intended to test our beta build of the scrooge-typescript sbt plugin.

Switched to sonatype bundled releases which are much faster to upload, and in so doing I noticed that we weren't actually releasing the cross-built libraries, so have fixed that.

We can now make beta release versions from a WIP branch too.

To create a beta release, start sbt with a RELEASE_TYPE variable;
`sbt -DRELEASE_TYPE=beta`
then release to sonatype/maven with
`release`
and follow prompts for version numbers etc.

To release to npm simply
`project typescriptLibraries`
then
`releaseNpm x.y.z-beta.n` where x, y, and z are your main, minor and patch version numbers, and n is your beta version number. We've made changes in the scrooge sbt plugin to apply a tag to the release, and that is set using `scroogeTypescriptPublishTag := "beta"` in `build.sbt` when we are running in beta mode as described above.
 
Using the above steps, this branch was used to make the following releases;
[content-entity-model 2.2.0-beta.3 for scala 2.12](https://repo1.maven.org/maven2/com/gu/content-entity-model_2.12/2.2.0-beta.3/)
[content-entity-model 2.2.0-beta.3 for scala 2.13](https://repo1.maven.org/maven2/com/gu/content-entity-model_2.13/2.2.0-beta.3/)
[content-entity-thrift 2.2.0-beta.3](https://repo1.maven.org/maven2/com/gu/content-entity-thrift/2.2.0-beta.3/)
and
[2.2.0-beta.3 for npm](https://www.npmjs.com/package/@guardian/content-entity-model/v/2.2.0-beta.3)

## How to test
Consume the beta build in dependent libraries and applications, then compile those to see if they experience any issues.

## How can we measure success?
If it builds, releases and doesn't cause downstream issues - success!

## Have we considered potential risks?
Clients / consumers must actively take up new version(s) so nothing will break as a direct result - although some of these changes, e.g. only supporting scala 2.12+ may cause clients some headaches. This may manifest as build failures in those applications.

## Images
N/A

## Accessibility

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
- [x] Not applicable

cc @idrise 