### PR TITLE
Complete release before setting next version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,8 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
     releaseStepCommandAndRemaining("+publishSigned"),
     releaseStepCommand("sonatypeBundleRelease"),
     setNextVersion,
-    commitNextVersion
+    commitNextVersion,
+    pushChanges
   )
 
   /*

--- a/build.sbt
+++ b/build.sbt
@@ -69,9 +69,9 @@ lazy val releaseProcessSteps: Seq[ReleaseStep] = {
     commitReleaseVersion,
     tagRelease,
     publishArtifacts,
-    setNextVersion,
     releaseStepCommandAndRemaining("+publishSigned"),
     releaseStepCommand("sonatypeBundleRelease"),
+    setNextVersion,
     commitNextVersion
   )
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.2.0"
+ThisBuild / version := "2.2.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.2.0-beta.5"
+ThisBuild / version := "2.2.0"


### PR DESCRIPTION
## What does this change?

In https://github.com/guardian/content-entity/pull/17 we made it possible to release beta versions, but this is the first time we're able to test the newer prod release steps, which seem be out of place and (I think) the version number is updating to `-SNAPSHOT` prematurely.

When running e.g.
```
$sbt
sbt:root> release
```
We see messages like
```
[info] Preparing a new staging repository for [sbt-sonatype] root 2.2.1-SNAPSHOT
```
which shouldn't have happened, it should have been releasing `2.2.0`. I think this is because
```
setNextVersion
```
was sitting before the
```
releaseStepCommand...
```
lines.

We can see `2.2.0` files being built locally but the release tries to look for `2.2.1-SNAPSHOT` which obviously don't (and shouldn't) exist.

## How to test

Unfortunately production releases can only be run against the master branch, so we'll have to merge and try again.


## How can we measure success?

It'll release without any errors

## Have we considered potential risks?

This should be pretty much risk-free until we've actually released a real version.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
- [x] Not applicable
