### PR TITLE
Use production release of our sbt-scrooge-typescript plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0-beta.6")
+addSbtPlugin("com.gu" % "sbt-scrooge-typescript" % "1.6.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 


### PR DESCRIPTION
## What does this change?

Sorry for all these PRs and releases 😞 

This one is to pick up and use the latest non-beta version of the sbt-scrooge-typescript plugin. I built the last version of this library with the beta, and it'd be cleaner if we release a version that was built with the final release version of that instead. Functionally nothing will have changed, it's just a hygiene thing really.

## How to test

We'll be bringing this library into other downstream libraries and applications, and will be testing it there. We've already done this during the various betas we've been going through lately so we don't expect to see any differences in behaviour.

## How can we measure success?

As mentioned - other dependent libraries and services consume this one, so we don't want to see any failing tests or unexpected behaviour in those. If that's the case - success!

## Have we considered potential risks?

This really should be risk-free.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
- [x] Not applicable

