### PR TITLE
Remove publish false to fix thrift package release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,8 @@ lazy val thrift = (project in file("thrift"))
     name := "content-entity-thrift",
     description := "Content entity model Thrift files",
     crossPaths := false,
-    publish / skip := true,
+    packageDoc / publishArtifact := false,
+    packageSrc / publishArtifact := false,
     Compile / unmanagedResourceDirectories += { baseDirectory.value / "src/main/thrift" }
   )
 


### PR DESCRIPTION
## What does this change?

During implementing the gha scala llibrary release process in PR #32 , mistakenly `thrift` package was made publish to false https://github.com/guardian/content-entity/pull/32#discussion_r1532568402 due to which thrift package didn't publish to maven during the release of v3.0.1. This change will back the original condition of publishing.

## How to test

By making release after merging this change.

## How can we measure success?

`content-entity-thrift` should also make its way to maven at https://repo1.maven.org/maven2/com/gu/content-entity-thrift/

