### PR TITLE
Test thrift release with version 3.0.0

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.0.2-SNAPSHOT"
+ThisBuild / version := "3.0.0-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

- We had an issue of `content-entity-thrift` not being released to maven after PR https://github.com/guardian/content-entity/pull/32 due to the error in making its publish to false.
(Note: `content-entity-model` was all fine hence was published with latest version of `v3.0.1`)
- The above issue was corrected in the PR https://github.com/guardian/content-entity/pull/36. 
- We are still getting issue on making release for `content-entity-thrift` package because release process is not able to find its`v3.0.1` on maven.
https://github.com/guardian/content-entity/actions/runs/8374220369

This is because `v3.0.1` was the release we made without `content-entity-thrift` (as mentioned above) and version.sbt has now updated to `v3.0.2-SNAPSHOT`

So to fix, this PR will test manual change in version.sbt to the version where `content-entity-thrift` didn't get release.
We need to test whether this does not have any issue with already released `3.0.1` of `content-entity-model`

## How to test

Make preview release with this PR.

## How can we measure success?

- If preview release can make release for `content-entity-thrift`
- If preview release doesn't have any conflict for `content-entity-model`

