### PR TITLE
Temporary disable compatibility check on releases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,6 @@ lazy val root = (project in file("."))
   .aggregate(thrift, scalaClasses)
   .settings(
     publish / skip := true,
-    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseCrossBuild := true,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,


### PR DESCRIPTION
Suggested by @rtyley  we can disable the releases checks to make succesful release this time, the release process is currently trying to find thrift latest release of 3.0.1 which is not available due to missed thing in PR https://github.com/guardian/content-entity/pull/32 which got fixed in PR https://github.com/guardian/content-entity/pull/36.

To fix the releases we will disable release comparison and make the release and then will enable again once releases goes well.

https://github.com/guardian/content-entity/pull/36#issuecomment-2020322629

## How to test

once this gets merged we will make release

## How can we measure success?

release should go well
