### PR TITLE
Enable release checks back again

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val root = (project in file("."))
   .aggregate(thrift, scalaClasses)
   .settings(
     publish / skip := true,
+    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseCrossBuild := true,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,


### PR DESCRIPTION
As we got successful releases after PR https://github.com/guardian/content-entity/pull/38 we can now re-add "AssessedCompatibilityWithLatestRelease" check in the sbt file.

## How to test

Make a new release once this PR gets merged.
This time Release process should be able to compare with previous release from maven for both `content-entity-model` and `content-entity-thrift` (which is at present `v3.0.2`) and should be able to make `v3.0.3` release without any problem.

## How can we measure success?

New release should go ahead without any issue. (we should expect `v3.0.3` once this PR gets merged).