### PR TITLE
Revert "Temporary disable compatibility check on releases"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val root = (project in file("."))
   .aggregate(thrift, scalaClasses)
   .settings(
     publish / skip := true,
+    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseCrossBuild := true,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,


### PR DESCRIPTION
As we got successful releases after PR https://github.com/guardian/content-entity/pull/38 we can now re-add "AssessedCompatibilityWithLatestRelease" check in the sbt file.
Hence reverting guardian/content-entity#38