### PR TITLE
add circe encoders and decoders as published artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,16 @@
 import sbtrelease._
 import ReleaseStateTransformations._
-import sbtrelease.ReleaseStateTransformations._
 import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 val scroogeVersion = "22.1.0"
 val thriftVersion = "0.20.0"
+val fezziwigVersion = "2.0.1"
+val circeVersion = "0.14.16"
 
 val artifactProductionSettings = Seq(
   organization := "com.gu",
   scmInfo := Some(ScmInfo(url("https://github.com/guardian/content-entity"), "scm:git@github.com:guardian/content-entity.git")),
-  scalaVersion := "2.13.12",
+  scalaVersion := "2.13.18",
   // scrooge 21.3.0: Builds are now only supported for Scala 2.12+
   // https://twitter.github.io/scrooge/changelog.html#id11
   crossScalaVersions := Seq("2.12.18", scalaVersion.value),
@@ -20,7 +21,7 @@ val artifactProductionSettings = Seq(
 
 lazy val root = (project in file("."))
   .settings(artifactProductionSettings)
-  .aggregate(thrift, scalaClasses)
+  .aggregate(thrift, scalaClasses, json)
   .settings(
     publish / skip := true,
     releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
@@ -65,6 +66,21 @@ lazy val thrift = (project in file("thrift"))
     packageDoc / publishArtifact := false,
     packageSrc / publishArtifact := false,
     Compile / unmanagedResourceDirectories += { baseDirectory.value / "src/main/thrift" }
+  )
+
+lazy val json = (project in file("json"))
+  .settings(artifactProductionSettings)
+  .dependsOn(scalaClasses)
+  .disablePlugins(ScroogeSBT)
+  .settings(
+    name := "content-entity-model-json",
+    description := "Circe json encoders and decoders for content entity model",
+    libraryDependencies ++= Seq(
+      "com.gu" %% "fezziwig" % fezziwigVersion,
+      "io.circe" %% "circe-core" % circeVersion,
+      "io.circe" %% "circe-generic" % circeVersion,
+      "io.circe" %% "circe-parser" % circeVersion,
+    )
   )
 
 lazy val typescriptClasses = (project in file("ts"))

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,8 @@ lazy val root = (project in file("."))
   .aggregate(thrift, scalaClasses, json)
   .settings(
     publish / skip := true,
-    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+    // TODO temporarily disabled for first release of json module. Reenable after first release
+    // releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseCrossBuild := true,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,

--- a/json/src/main/scala/com/gu/contententity/json/CirceDecoders.scala
+++ b/json/src/main/scala/com/gu/contententity/json/CirceDecoders.scala
@@ -1,0 +1,28 @@
+package com.gu.contententity.json
+
+import com.gu.contententity.thrift.entity.film.Film
+import com.gu.contententity.thrift.entity.game.Game
+import com.gu.contententity.thrift.entity.organisation.Organisation
+import com.gu.contententity.thrift.entity.person.Person
+import com.gu.contententity.thrift.entity.place.Place
+import com.gu.contententity.thrift.entity.restaurant.Restaurant
+import com.gu.contententity.thrift.{Address, EntityType, Geolocation, Price}
+import com.gu.fezziwig.CirceScroogeMacros._
+import com.gu.fezziwig.CirceScroogeWhiteboxMacros._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+object CirceDecoders {
+  implicit lazy val filmDecoder: Decoder[Film] = deriveDecoder
+  implicit lazy val gameDecoder: Decoder[Game] = deriveDecoder
+  implicit lazy val organisationDecoder: Decoder[Organisation] = deriveDecoder
+  implicit lazy val personDecoder: Decoder[Person] = deriveDecoder
+  implicit lazy val placeDecoder: Decoder[Place] = deriveDecoder
+  implicit lazy val restaurantDecoder: Decoder[Restaurant] = deriveDecoder
+
+  implicit lazy val entityTypeDecoder: Decoder[EntityType] = deriveDecoder
+
+  implicit lazy val addressDecoder: Decoder[Address] = deriveDecoder
+  implicit lazy val geolocationDecoder: Decoder[Geolocation] = deriveDecoder
+  implicit lazy val priceDecoder: Decoder[Price] = deriveDecoder
+}

--- a/json/src/main/scala/com/gu/contententity/json/CirceEncoders.scala
+++ b/json/src/main/scala/com/gu/contententity/json/CirceEncoders.scala
@@ -1,0 +1,28 @@
+package com.gu.contententity.json
+
+import com.gu.contententity.thrift.{Address, EntityType, Geolocation, Price}
+import com.gu.contententity.thrift.entity.film.Film
+import com.gu.contententity.thrift.entity.game.Game
+import com.gu.contententity.thrift.entity.organisation.Organisation
+import com.gu.contententity.thrift.entity.person.Person
+import com.gu.contententity.thrift.entity.place.Place
+import com.gu.contententity.thrift.entity.restaurant.Restaurant
+import com.gu.fezziwig.CirceScroogeMacros._
+import com.gu.fezziwig.CirceScroogeWhiteboxMacros._
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
+
+object CirceEncoders {
+  implicit lazy val filmEncoder: Encoder[Film] = deriveEncoder
+  implicit lazy val gameEncoder: Encoder[Game] = deriveEncoder
+  implicit lazy val organisationEncoder: Encoder[Organisation] = deriveEncoder
+  implicit lazy val personEncoder: Encoder[Person] = deriveEncoder
+  implicit lazy val placeEncoder: Encoder[Place] = deriveEncoder
+  implicit lazy val restaurantEncoder: Encoder[Restaurant] = deriveEncoder
+
+  implicit lazy val entityTypeEncoder: Encoder[EntityType] = deriveEncoder
+
+  implicit lazy val addressEncoder: Encoder[Address] = deriveEncoder
+  implicit lazy val geolocationEncoder: Encoder[Geolocation] = deriveEncoder
+  implicit lazy val priceEncoder: Encoder[Price] = deriveEncoder
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.12.13

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.0.1-SNAPSHOT"
+ThisBuild / version := "4.1.0-SNAPSHOT"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds circe encoders and decoders as a published artifact, to avoid each consumer needing to write the list of encoders and decoders themselves.

## How has this change been tested?

TBD

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
